### PR TITLE
Migrate linting from pre-commit.ci to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ env:
   UV_SYSTEM_PYTHON: 1
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+      - name: Run prek
+        uses: j178/prek-action@v2
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -49,6 +57,15 @@ jobs:
         run: python -m coverage xml
       - name: Coveralls
         uses: coverallsapp/github-action@v2
+
+  checks:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Check all jobs passed
+        run: |
+          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
 
   release:
     if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/update-hooks.yml
+++ b/.github/workflows/update-hooks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          token: ${{ secrets.PREK_UPDATE_TOKEN }}
+          token: ${{ secrets.AUTOMATION_TOKEN }}
       - name: Install prek
         uses: j178/prek-action@v2
         with:
@@ -38,7 +38,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PREK_UPDATE_TOKEN }}
+          token: ${{ secrets.AUTOMATION_TOKEN }}
           commit-message: Update pre-commit hooks
           title: Update pre-commit hooks
           body: Automated hook update from the `update-hooks` workflow, using `prek update`.

--- a/.github/workflows/update-hooks.yml
+++ b/.github/workflows/update-hooks.yml
@@ -1,0 +1,60 @@
+name: Update hooks
+
+on:
+  schedule:
+    - cron: "27 5 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.PREK_UPDATE_TOKEN }}
+      - name: Install prek
+        uses: j178/prek-action@v2
+        with:
+          install-only: true
+      - name: Update hook versions
+        run: prek update
+      - name: Run hooks
+        run: prek run --all-files || prek run --all-files || true
+      - name: Check which files changed
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ] && [ "$(git diff --name-only)" = ".pre-commit-config.yaml" ]; then
+            echo "config-only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "config-only=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create pull request
+        id: pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PREK_UPDATE_TOKEN }}
+          commit-message: Update pre-commit hooks
+          title: Update pre-commit hooks
+          body: Automated hook update from the `update-hooks` workflow, using `prek update`.
+          branch: update-pre-commit-hooks
+          delete-branch: true
+      - name: Enable auto-merge
+        if: steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          gh pr merge --squash --auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" ||
+            echo "::warning::Could not enable auto-merge"
+      - name: Approve if only the hook config changed
+        if: steps.changes.outputs.config-only == 'true' && (steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Replaces pre-commit.ci with [prek](https://github.com/j178/prek), run directly in GitHub Actions:

- New `lint` job in CI runs the existing hooks via `j178/prek-action`.
- New weekly `update-hooks` workflow replaces pre-commit.ci autoupdate: it runs `prek update`, applies any fixes, opens a PR with auto-merge enabled, and auto-approves it when the diff only touches `.pre-commit-config.yaml`.

The update workflow uses the `AUTOMATION_TOKEN` repository secret (fine-grained PAT, already configured) so its PRs trigger CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)