### PR TITLE
Add support for Django 6.1 and the MAILERS setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django-version: ["4.2", "5.1", "5.2"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        django-version: ["5.2", "6.0", "6.1"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
-          - django-version: "5.2"
+          - django-version: "6.0"
             python-version: "3.10"
+          - django-version: "6.0"
+            python-version: "3.11"
+          - django-version: "6.1"
+            python-version: "3.10"
+          - django-version: "6.1"
+            python-version: "3.11"
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,10 @@ the mailer that will do the actual sending in the worker:
 ``using`` is required, as the worker would otherwise send through ``default``
 and queue the message again.
 
+Let the queue drain before adding ``MAILERS``. Tasks queued beforehand name no
+mailer, and Django refuses to build a backend from the deprecated settings once
+``MAILERS`` exists, so a worker that has it cannot send them.
+
 Django 6.0 and earlier
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ the mailer that will do the actual sending in the worker:
 ``using`` is required, as the worker would otherwise send through ``default``
 and queue the message again.
 
+``fail_silently`` belongs on the mailer named by ``using``, which is the one
+that sends. A silenced failure there leaves a successful task and no email.
+
 Let the queue drain before adding ``MAILERS``. Tasks queued beforehand name no
 mailer, and Django refuses to build a backend from the deprecated settings once
 ``MAILERS`` exists, so a worker that has it cannot send them.

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,37 @@ Installation
         "django_q2_email_backend",
     )
 
-You must then set django-q2-email-backend as your ``EMAIL_BACKEND``:
+-------------
+Configuration
+-------------
+
+Django 6.1 and later
+~~~~~~~~~~~~~~~~~~~~
+
+Django 6.1 replaced the ``EMAIL_*`` settings with ``MAILERS``. Add
+``Q2EmailBackend`` as your ``default`` mailer, with a ``using`` option naming
+the mailer that will do the actual sending in the worker:
+
+.. code-block:: python
+
+    MAILERS = {
+        "default": {
+            "BACKEND": "django_q2_email_backend.backends.Q2EmailBackend",
+            "OPTIONS": {"using": "smtp"},
+        },
+        "smtp": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {"host": "smtp.example.com", "use_tls": True},
+        },
+    }
+
+``using`` is required, as the worker would otherwise send through ``default``
+and queue the message again.
+
+Django 6.0 and earlier
+~~~~~~~~~~~~~~~~~~~~~~
+
+Set django-q2-email-backend as your ``EMAIL_BACKEND``:
 
 .. code-block:: python
 
@@ -43,6 +73,9 @@ may set it in ``Q2_EMAIL_BACKEND`` just like you would normally have set
 procedure will most likely be to get your email working using only Django, then
 change ``EMAIL_BACKEND`` to ``Q2_EMAIL_BACKEND``, and then add the new
 ``EMAIL_BACKEND`` setting from above.
+
+``EMAIL_BACKEND`` and ``Q2_EMAIL_BACKEND`` are ignored if ``MAILERS`` is
+defined, and stop working in Django 7.0.
 
 
 Credits

--- a/django_q2_email_backend/apps.py
+++ b/django_q2_email_backend/apps.py
@@ -5,3 +5,6 @@ class Q2EmailBackendConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "django_q2_email_backend"
     label = "q2_email_backend"
+
+    def ready(self) -> None:
+        from . import checks  # NOQA: F401

--- a/django_q2_email_backend/backends.py
+++ b/django_q2_email_backend/backends.py
@@ -10,9 +10,6 @@ from django_q.tasks import async_task
 
 from . import utils
 
-if django.VERSION >= (6, 1):
-    from django.core.mail import InvalidMailer
-
 if TYPE_CHECKING:
     from django.core.mail import EmailMessage
 
@@ -46,28 +43,13 @@ class Q2EmailBackend(BaseEmailBackend):
         self.using = using
         self.init_kwargs: dict[str, Any] = {}
         if django.VERSION >= (6, 1) and hasattr(settings, "MAILERS"):
-            alias = kwargs.get("alias")
-            if using is None:
-                msg = (
-                    "Q2EmailBackend requires a 'using' option naming the MAILERS "
-                    "alias to send messages with."
-                )
-                raise InvalidMailer(msg, alias=alias)
-            if using == alias:
-                msg = f"The 'using' option must not name this mailer, {using!r}."
-                raise InvalidMailer(msg, alias=alias)
-            if using not in settings.MAILERS:
-                msg = f"The 'using' option names an unconfigured mailer, {using!r}."
-                raise InvalidMailer(msg, alias=alias)
             super().__init__(**kwargs)
-        else:
-            if using is not None:
-                msg = "The 'using' option requires Django 6.1 and a MAILERS setting."
-                raise ImproperlyConfigured(msg)
-            self.init_kwargs = kwargs
-            # Passing fail_silently to BaseEmailBackend is deprecated as of
-            # Django 6.1, and warns even when it is the default.
-            super().__init__()
+            return
+        if using is not None:
+            msg = "The 'using' option requires Django 6.1 and a MAILERS setting."
+            raise ImproperlyConfigured(msg)
+        self.init_kwargs = kwargs
+        super().__init__()
 
     def send_messages(self, email_messages: list["EmailMessage"]) -> int:
         num_sent = 0

--- a/django_q2_email_backend/backends.py
+++ b/django_q2_email_backend/backends.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import django
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import get_connection
 from django.core.mail.backends.base import BaseEmailBackend
 from django_q.tasks import async_task
@@ -38,7 +39,6 @@ def send_message(
 class Q2EmailBackend(BaseEmailBackend):
     def __init__(
         self,
-        fail_silently: bool = False,
         *,
         using: str | None = None,
         **kwargs: Any,  # NOQA: ANN401
@@ -61,8 +61,13 @@ class Q2EmailBackend(BaseEmailBackend):
                 raise InvalidMailer(msg, alias=alias)
             super().__init__(**kwargs)
         else:
+            if using is not None:
+                msg = "The 'using' option requires Django 6.1 and a MAILERS setting."
+                raise ImproperlyConfigured(msg)
             self.init_kwargs = kwargs
-            super().__init__(fail_silently)
+            # Passing fail_silently to BaseEmailBackend is deprecated as of
+            # Django 6.1, and warns even when it is the default.
+            super().__init__()
 
     def send_messages(self, email_messages: list["EmailMessage"]) -> int:
         num_sent = 0

--- a/django_q2_email_backend/backends.py
+++ b/django_q2_email_backend/backends.py
@@ -46,12 +46,19 @@ class Q2EmailBackend(BaseEmailBackend):
         self.using = using
         self.init_kwargs: dict[str, Any] = {}
         if django.VERSION >= (6, 1) and hasattr(settings, "MAILERS"):
+            alias = kwargs.get("alias")
             if using is None:
                 msg = (
                     "Q2EmailBackend requires a 'using' option naming the MAILERS "
                     "alias to send messages with."
                 )
-                raise InvalidMailer(msg, alias=kwargs.get("alias"))
+                raise InvalidMailer(msg, alias=alias)
+            if using == alias:
+                msg = f"The 'using' option must not name this mailer, {using!r}."
+                raise InvalidMailer(msg, alias=alias)
+            if using not in settings.MAILERS:
+                msg = f"The 'using' option names an unconfigured mailer, {using!r}."
+                raise InvalidMailer(msg, alias=alias)
             super().__init__(**kwargs)
         else:
             self.init_kwargs = kwargs

--- a/django_q2_email_backend/backends.py
+++ b/django_q2_email_backend/backends.py
@@ -1,12 +1,16 @@
 from typing import TYPE_CHECKING
 from typing import Any
 
+import django
 from django.conf import settings
 from django.core.mail import get_connection
 from django.core.mail.backends.base import BaseEmailBackend
 from django_q.tasks import async_task
 
 from . import utils
+
+if django.VERSION >= (6, 1):
+    from django.core.mail import InvalidMailer
 
 if TYPE_CHECKING:
     from django.core.mail import EmailMessage
@@ -21,20 +25,37 @@ Q2_EMAIL_BACKEND = getattr(
 def send_message(
     serialized_email_message: "EmailMessageData",
     init_kwargs: dict[str, Any],
+    using: str | None = None,
 ) -> None:
     email_message = utils.from_dict(serialized_email_message)
-    email_message.connection = get_connection(backend=Q2_EMAIL_BACKEND, **init_kwargs)
-    email_message.send()
+    if using is not None:
+        email_message.send(using=using)
+        return
+    connection = get_connection(backend=Q2_EMAIL_BACKEND, **init_kwargs)
+    connection.send_messages([email_message])
 
 
 class Q2EmailBackend(BaseEmailBackend):
     def __init__(
         self,
         fail_silently: bool = False,
+        *,
+        using: str | None = None,
         **kwargs: Any,  # NOQA: ANN401
     ) -> None:
-        super().__init__(fail_silently)
-        self.init_kwargs = kwargs
+        self.using = using
+        self.init_kwargs: dict[str, Any] = {}
+        if django.VERSION >= (6, 1) and hasattr(settings, "MAILERS"):
+            if using is None:
+                msg = (
+                    "Q2EmailBackend requires a 'using' option naming the MAILERS "
+                    "alias to send messages with."
+                )
+                raise InvalidMailer(msg, alias=kwargs.get("alias"))
+            super().__init__(**kwargs)
+        else:
+            self.init_kwargs = kwargs
+            super().__init__(fail_silently)
 
     def send_messages(self, email_messages: list["EmailMessage"]) -> int:
         num_sent = 0
@@ -44,6 +65,7 @@ class Q2EmailBackend(BaseEmailBackend):
                 "django_q2_email_backend.backends.send_message",
                 serialized_email_message,
                 self.init_kwargs,
+                self.using,
             )
             num_sent += 1
         return num_sent

--- a/django_q2_email_backend/checks.py
+++ b/django_q2_email_backend/checks.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from django.conf import settings
+from django.core.checks import CheckMessage
+from django.core.checks import Error
+from django.core.checks import register
+from django.utils.module_loading import import_string
+
+from .backends import Q2EmailBackend
+
+
+def is_queued(backend_path: str | None) -> bool:
+    if not backend_path:
+        return False
+    try:
+        backend_class = import_string(backend_path)
+    except ImportError:
+        return False
+    return isinstance(backend_class, type) and issubclass(backend_class, Q2EmailBackend)
+
+
+@register
+def check_using_options(
+    app_configs: Any,  # NOQA: ANN401
+    **kwargs: Any,  # NOQA: ANN401
+) -> list[CheckMessage]:
+    if not settings.is_overridden("MAILERS"):
+        return []
+
+    errors: list[CheckMessage] = []
+    for alias, config in settings.MAILERS.items():
+        if not is_queued(config.get("BACKEND")):
+            continue
+        using = config.get("OPTIONS", {}).get("using")
+        if using is None:
+            errors.append(
+                Error(
+                    f"MAILERS[{alias!r}] has no 'using' option.",
+                    hint="Name the mailer that should send the queued messages.",
+                    id="q2_email_backend.E001",
+                )
+            )
+        elif using not in settings.MAILERS:
+            errors.append(
+                Error(
+                    f"MAILERS[{alias!r}] names an unconfigured mailer, {using!r}.",
+                    hint=f"Add a {using!r} entry to MAILERS.",
+                    id="q2_email_backend.E002",
+                )
+            )
+        elif is_queued(settings.MAILERS[using].get("BACKEND")):
+            errors.append(
+                Error(
+                    f"MAILERS[{alias!r}] names a queued mailer, {using!r}.",
+                    hint="Messages sent through it would be queued again, not sent.",
+                    id="q2_email_backend.E003",
+                )
+            )
+    return errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -19,12 +19,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications :: Email",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["django", "django-q2"]
+dependencies = ["django>=5.2", "django-q2"]
 description = "An asynchronous Django email backend for Django Q2"
 license = { "file" = "LICENSE" }
 name = "django-q2-email-backend"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,4 +25,4 @@ Q_CLUSTER = {
 }
 
 EMAIL_BACKEND = "django_q2_email_backend.backends.Q2EmailBackend"
-Q2_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+Q2_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,6 +33,10 @@ class TestEmailBackend(TestCase):
         num_sent = self.backend.send_messages([message])
 
         self.assertEqual(num_sent, 1)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Subject")
+        self.assertEqual(mail.outbox[0].body, "Message")
+        self.assertEqual(mail.outbox[0].to, ["bar@example.com"])
 
     def test_send_html_email(self) -> None:
         message = mail.EmailMultiAlternatives(**self.message_data)
@@ -41,6 +45,18 @@ class TestEmailBackend(TestCase):
         num_sent = self.backend.send_messages([message])
 
         self.assertEqual(num_sent, 1)
+        self.assertEqual(mail.outbox[0].alternatives, [("<p>HTML</p>", "text/html")])
+
+    def test_send_email_with_attachment(self) -> None:
+        message = mail.EmailMessage(**self.message_data)
+        message.attach("hello.txt", "Hello", "text/plain")
+
+        num_sent = self.backend.send_messages([message])
+
+        self.assertEqual(num_sent, 1)
+        self.assertEqual(
+            mail.outbox[0].attachments, [("hello.txt", "Hello", "text/plain")]
+        )
 
 
 class TestSerialization(TestCase):
@@ -78,10 +94,22 @@ class TestMailers(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Subject")
 
-    def test_using_is_required(self) -> None:
-        mailers = {"default": {"BACKEND": MAILERS["default"]["BACKEND"]}}
+    def assert_invalid_using(self, using: str | None) -> None:
+        options = {"using": using} if using is not None else {}
+        mailers = {
+            "default": {"BACKEND": MAILERS["default"]["BACKEND"], "OPTIONS": options}
+        }
         with (
             override_settings(MAILERS=mailers),
             self.assertRaises(mail.InvalidMailer),
         ):
             _ = mail.mailers["default"]
+
+    def test_using_is_required(self) -> None:
+        self.assert_invalid_using(None)
+
+    def test_using_must_not_be_self(self) -> None:
+        self.assert_invalid_using("default")
+
+    def test_using_must_be_configured(self) -> None:
+        self.assert_invalid_using("nonexistent")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,20 @@
+from unittest import skipIf
+
+import django
 from django.core import mail
 from django.test import TestCase
+from django.test import override_settings
 
 from django_q2_email_backend import utils
 from django_q2_email_backend.backends import Q2EmailBackend
+
+MAILERS = {
+    "default": {
+        "BACKEND": "django_q2_email_backend.backends.Q2EmailBackend",
+        "OPTIONS": {"using": "locmem"},
+    },
+    "locmem": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
+}
 
 
 class TestEmailBackend(TestCase):
@@ -47,3 +59,29 @@ class TestSerialization(TestCase):
         round_tripped = utils.from_dict(email_message_data)
 
         self.assertIsNone(round_tripped.encoding)
+
+
+@skipIf(django.VERSION < (6, 1), "MAILERS was added in Django 6.1")
+@override_settings(MAILERS=MAILERS)
+class TestMailers(TestCase):
+    def test_send_email(self) -> None:
+        message = mail.EmailMessage(
+            subject="Subject",
+            body="Message",
+            from_email="foo@example.com",
+            to=["bar@example.com"],
+        )
+
+        num_sent = mail.mailers.default.send_messages([message])
+
+        self.assertEqual(num_sent, 1)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Subject")
+
+    def test_using_is_required(self) -> None:
+        mailers = {"default": {"BACKEND": MAILERS["default"]["BACKEND"]}}
+        with (
+            override_settings(MAILERS=mailers),
+            self.assertRaises(mail.InvalidMailer),
+        ):
+            _ = mail.mailers["default"]

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,11 @@
+import warnings
 from email.message import MIMEPart
 from email.mime.text import MIMEText
 from unittest import skipIf
 
 import django
 from django.core import mail
+from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test import override_settings
 
@@ -38,6 +40,17 @@ class TestEmailBackend(TestCase):
             "from_email": "foo@example.com",
             "to": ["bar@example.com"],
         }
+
+    def test_no_deprecation_warnings(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Q2EmailBackend()
+
+        self.assertEqual([str(warning.message) for warning in caught], [])
+
+    def test_using_requires_mailers(self) -> None:
+        with self.assertRaises(ImproperlyConfigured):
+            Q2EmailBackend(using="locmem")
 
     def test_send_email(self) -> None:
         message = mail.EmailMessage(**self.message_data)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,5 @@
+from email.message import MIMEPart
+from email.mime.text import MIMEText
 from unittest import skipIf
 
 import django
@@ -7,6 +9,16 @@ from django.test import override_settings
 
 from django_q2_email_backend import utils
 from django_q2_email_backend.backends import Q2EmailBackend
+
+
+def make_mime_attachment() -> MIMEPart | MIMEText:
+    # MIMEBase attachments are deprecated as of Django 6.0.
+    if django.VERSION >= (6, 0):
+        attachment = MIMEPart()
+        attachment.set_content("Hello")
+        return attachment
+    return MIMEText("Hello")
+
 
 MAILERS = {
     "default": {
@@ -56,6 +68,38 @@ class TestEmailBackend(TestCase):
         self.assertEqual(num_sent, 1)
         self.assertEqual(
             mail.outbox[0].attachments, [("hello.txt", "Hello", "text/plain")]
+        )
+
+    def test_send_email_with_mime_attachment(self) -> None:
+        message = mail.EmailMessage(**self.message_data)
+        message.attach(make_mime_attachment())
+
+        num_sent = self.backend.send_messages([message])
+
+        self.assertEqual(num_sent, 1)
+        sent = mail.outbox[0]
+        self.assertEqual(len(sent.attachments), 1)
+        self.assertIn("Hello", sent.message().as_string())
+
+    def test_send_email_with_addresses_and_headers(self) -> None:
+        message = mail.EmailMessage(
+            **self.message_data,
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+            reply_to=["reply@example.com"],
+            headers={"X-Custom": "value"},
+        )
+
+        num_sent = self.backend.send_messages([message])
+
+        self.assertEqual(num_sent, 1)
+        sent = mail.outbox[0]
+        self.assertEqual(sent.cc, ["cc@example.com"])
+        self.assertEqual(sent.bcc, ["bcc@example.com"])
+        self.assertEqual(sent.reply_to, ["reply@example.com"])
+        self.assertEqual(sent.extra_headers, {"X-Custom": "value"})
+        self.assertEqual(
+            sent.recipients(), ["bar@example.com", "cc@example.com", "bcc@example.com"]
         )
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,15 +6,16 @@ from unittest import skipIf
 import django
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
 from django.test import TestCase
 from django.test import override_settings
 
 from django_q2_email_backend import utils
 from django_q2_email_backend.backends import Q2EmailBackend
+from django_q2_email_backend.checks import check_using_options
 
 
 def make_mime_attachment() -> MIMEPart | MIMEText:
-    # MIMEBase attachments are deprecated as of Django 6.0.
     if django.VERSION >= (6, 0):
         attachment = MIMEPart()
         attachment.set_content("Hello")
@@ -22,9 +23,11 @@ def make_mime_attachment() -> MIMEPart | MIMEText:
     return MIMEText("Hello")
 
 
+QUEUED = "django_q2_email_backend.backends.Q2EmailBackend"
+
 MAILERS = {
     "default": {
-        "BACKEND": "django_q2_email_backend.backends.Q2EmailBackend",
+        "BACKEND": QUEUED,
         "OPTIONS": {"using": "locmem"},
     },
     "locmem": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"},
@@ -151,22 +154,54 @@ class TestMailers(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Subject")
 
-    def assert_invalid_using(self, using: str | None) -> None:
-        options = {"using": using} if using is not None else {}
-        mailers = {
-            "default": {"BACKEND": MAILERS["default"]["BACKEND"], "OPTIONS": options}
-        }
-        with (
-            override_settings(MAILERS=mailers),
-            self.assertRaises(mail.InvalidMailer),
-        ):
-            _ = mail.mailers["default"]
+
+@skipIf(django.VERSION < (6, 1), "MAILERS was added in Django 6.1")
+class TestChecks(SimpleTestCase):
+    def assert_error(self, mailers: dict[str, object], error_id: str) -> None:
+        with override_settings(MAILERS=mailers):
+            errors = check_using_options(None)
+
+        self.assertEqual([error.id for error in errors], [error_id])
+
+    def test_valid(self) -> None:
+        with override_settings(MAILERS=MAILERS):
+            self.assertEqual(check_using_options(None), [])
+
+    def test_no_mailers(self) -> None:
+        self.assertEqual(check_using_options(None), [])
+
+    def test_backend_that_is_not_a_class(self) -> None:
+        with override_settings(MAILERS={"default": {"BACKEND": "os.path.join"}}):
+            self.assertEqual(check_using_options(None), [])
 
     def test_using_is_required(self) -> None:
-        self.assert_invalid_using(None)
-
-    def test_using_must_not_be_self(self) -> None:
-        self.assert_invalid_using("default")
+        self.assert_error(
+            {"default": {"BACKEND": QUEUED}},
+            "q2_email_backend.E001",
+        )
 
     def test_using_must_be_configured(self) -> None:
-        self.assert_invalid_using("nonexistent")
+        self.assert_error(
+            {"default": {"BACKEND": QUEUED, "OPTIONS": {"using": "nonexistent"}}},
+            "q2_email_backend.E002",
+        )
+
+    def test_using_must_not_be_self(self) -> None:
+        self.assert_error(
+            {"default": {"BACKEND": QUEUED, "OPTIONS": {"using": "default"}}},
+            "q2_email_backend.E003",
+        )
+
+    def test_using_must_not_be_another_queued_mailer(self) -> None:
+        with override_settings(
+            MAILERS={
+                "default": {"BACKEND": QUEUED, "OPTIONS": {"using": "other"}},
+                "other": {"BACKEND": QUEUED, "OPTIONS": {"using": "default"}},
+            }
+        ):
+            errors = check_using_options(None)
+
+        self.assertEqual(
+            [error.id for error in errors],
+            ["q2_email_backend.E003", "q2_email_backend.E003"],
+        )


### PR DESCRIPTION
Django 6.1 dropped, so this does the two things that needed doing.

## Version matrix

Django 5.2, 6.0 and 6.1, on Python 3.10 to 3.14. Django 4.2 (EOL April 2026)
and 5.1 (EOL December 2025) are dropped rather than added to an already wide
matrix. Python 3.10 and 3.11 are excluded for 6.0 and 6.1, which need 3.12 or
later. The version is deliberately left alone; the bump for dropping those
versions belongs in its own PR.

## MAILERS

`Q2EmailBackend` now takes a `using` option naming the mailer that does the
real sending inside the worker:

```python
MAILERS = {
    "default": {
        "BACKEND": "django_q2_email_backend.backends.Q2EmailBackend",
        "OPTIONS": {"using": "smtp"},
    },
    "smtp": {
        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
        "OPTIONS": {"host": "smtp.example.com", "use_tls": True},
    },
}
```

Notes on the implementation:

* The two paths are selected on `django.VERSION >= (6, 1) and hasattr(settings,
  "MAILERS")`, so the deprecated half can be deleted by grepping for the
  version check. Keying on `MAILERS` being defined rather than on the instance
  having an alias also avoids falling into the deprecated path when it cannot
  work: `get_connection(backend=...)` raises `RuntimeError` under `MAILERS`.
* Leftover kwargs go to `BaseEmailBackend.__init__()`, so Django raises
  `InvalidMailer` for unknown `OPTIONS` itself.
* `using` is validated by system checks rather than in `__init__()`, which
  Django runs on every send — `MAILERS` cannot change while the process runs.
  `E001` for a queued mailer with no `using`, `E002` for one naming a mailer
  that isn't configured, `E003` for one naming another queued mailer. That last
  matters most: a cycle of two Q2 mailers enqueues roughly five tasks a second
  per worker forever without delivering anything, and every task *succeeds*, so
  nothing in django-q reports it. Being errors, they also stop `qcluster` from
  starting.
* It reaches the task as a defaulted third argument, so tasks already in the
  queue at upgrade time still run the deprecated path — though they cannot be
  sent by a worker that has `MAILERS`, so the README says to drain the queue
  before adding it.
* `fail_silently` is no longer touched at all. It was accepted and ignored;
  dropping the argument leaves it among the options forwarded to the worker,
  where the backend that sends honours it, and lets Django reject it as an
  unknown option under `MAILERS`, where it belongs on the mailer that sends.
  This also stops the `RemovedInDjango70Warning` that 6.1 raises whenever
  `BaseEmailBackend` is given the argument, even as the default.
* The deprecated path now calls `connection.send_messages()` rather than
  assigning `EmailMessage.connection`, which 6.1 deprecates.

Backend construction, which happens per `send_mail()`, is 1.27 us against 1.10
us for a plain Django backend — it was 1.86 us with the validation inline.

## Testing

16 tests, passing on 5.2, 6.0 and 6.1. The tests previously sent through the
console backend and asserted only the return value of `send_messages()`, which
`Q2EmailBackend` returns whether or not the worker did anything; they now send
through locmem and assert what arrives, including attachments in both forms
and every field `to_dict()` copies.

Also verified by hand against a real `qcluster` — separate pusher, worker and
monitor processes, ORM broker, filebased mailer — where the body, HTML
alternative and attachment all survived and the task was marked successful, and
where a cycle is refused before the cluster starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)