### PR TITLE
Serialize EmailMessage.encoding

### DIFF
--- a/django_q2_email_backend/typing.py
+++ b/django_q2_email_backend/typing.py
@@ -19,5 +19,6 @@ if TYPE_CHECKING:
 
     class OptionalEmailMessageData(TypedDict, total=False):
         alternatives: list[tuple[str, str]] | None
+        encoding: str | None
 
     class EmailMessageData(RequiredEmailMessageData, OptionalEmailMessageData): ...

--- a/django_q2_email_backend/utils.py
+++ b/django_q2_email_backend/utils.py
@@ -18,6 +18,7 @@ def to_dict(email_message: EmailMessage) -> dict[str, str]:
         "attachments": email_message.attachments,
         "headers": email_message.extra_headers,
         "reply_to": email_message.reply_to,
+        "encoding": email_message.encoding,
     }
     if isinstance(email_message, EmailMultiAlternatives):
         email_message_data["alternatives"] = email_message.alternatives
@@ -26,6 +27,10 @@ def to_dict(email_message: EmailMessage) -> dict[str, str]:
 
 def from_dict(email_message_data: "EmailMessageData") -> EmailMessage:
     kwargs = dict(email_message_data)
+    encoding = kwargs.pop("encoding", None)
     if alternatives := kwargs.pop("alternatives", None):
-        return EmailMultiAlternatives(alternatives=alternatives, **kwargs)
-    return EmailMessage(**kwargs)
+        email_message = EmailMultiAlternatives(alternatives=alternatives, **kwargs)
+    else:
+        email_message = EmailMessage(**kwargs)
+    email_message.encoding = encoding
+    return email_message

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 from django.core import mail
 from django.test import TestCase
 
+from django_q2_email_backend import utils
 from django_q2_email_backend.backends import Q2EmailBackend
 
 
@@ -28,3 +29,21 @@ class TestEmailBackend(TestCase):
         num_sent = self.backend.send_messages([message])
 
         self.assertEqual(num_sent, 1)
+
+
+class TestSerialization(TestCase):
+    def test_encoding(self) -> None:
+        message = mail.EmailMessage(subject="Subject", body="Message")
+        message.encoding = "iso-8859-1"
+
+        round_tripped = utils.from_dict(utils.to_dict(message))
+
+        self.assertEqual(round_tripped.encoding, "iso-8859-1")
+
+    def test_encoding_absent(self) -> None:
+        email_message_data = utils.to_dict(mail.EmailMessage(subject="Subject"))
+        del email_message_data["encoding"]
+
+        round_tripped = utils.from_dict(email_message_data)
+
+        self.assertIsNone(round_tripped.encoding)


### PR DESCRIPTION
`to_dict()` never copied `EmailMessage.encoding`, so a message that sets a
non-default charset was re-encoded with `DEFAULT_CHARSET` in the worker. No
error, just a differently encoded email than the one that was sent.

```python
message = EmailMessage(subject="Grüße", body="…")
message.encoding = "iso-8859-1"   # ignored, arrives as utf-8
```

`encoding` is a class attribute rather than a constructor argument, so
`from_dict()` assigns it after building the message. It is optional in
`EmailMessageData` because tasks queued by an earlier version have no such
key; `pop()` defaults to `None`, which is also the class default, so those
messages behave exactly as they do today.

Found while reviewing #98, unrelated to it.

## Testing

Two tests, both red before the change (`KeyError: 'encoding'` and
`AssertionError: None != 'iso-8859-1'`): one round-trips a message with an
explicit encoding, one round-trips a payload with the key removed, covering
tasks already in the queue at upgrade time. Passing on Django 5.2, 6.0 and
6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)