### PR TITLE
Honour fail_silently

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,9 @@ the mailer that will do the actual sending in the worker:
 ``using`` is required, as the worker would otherwise send through ``default``
 and queue the message again.
 
+``fail_silently`` belongs on the mailer named by ``using``, which is the one
+that sends. A silenced failure there leaves a successful task and no email.
+
 Let the queue drain before adding ``MAILERS``. Tasks queued beforehand name no
 mailer, and Django refuses to build a backend from the deprecated settings once
 ``MAILERS`` exists, so a worker that has it cannot send them.

--- a/django_q2_email_backend/backends.py
+++ b/django_q2_email_backend/backends.py
@@ -72,8 +72,10 @@ class Q2EmailBackend(BaseEmailBackend):
                 msg = "The 'using' option requires Django 6.1 and a MAILERS setting."
                 raise ImproperlyConfigured(msg)
             self.init_kwargs = kwargs
+            if fail_silently:
+                self.init_kwargs["fail_silently"] = True
             super().__init__()
-            self.fail_silently = fail_silently
+        self.fail_silently = fail_silently
 
     def send_messages(self, email_messages: list["EmailMessage"]) -> int:
         num_sent = 0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import warnings
 from email.message import MIMEPart
 from email.mime.text import MIMEText
 from unittest import skipIf
+from unittest.mock import patch
 
 import django
 from django.core import mail
@@ -19,6 +20,8 @@ def make_mime_attachment() -> MIMEPart | MIMEText:
         return attachment
     return MIMEText("Hello")
 
+
+TARGET_ASYNC_TASK = "django_q2_email_backend.backends.async_task"
 
 MAILERS = {
     "default": {
@@ -49,6 +52,21 @@ class TestEmailBackend(TestCase):
     def test_using_requires_mailers(self) -> None:
         with self.assertRaises(ImproperlyConfigured):
             Q2EmailBackend(using="locmem")
+
+    def test_fail_silently_reaches_the_worker(self) -> None:
+        backend = Q2EmailBackend(fail_silently=True)
+
+        self.assertEqual(backend.init_kwargs, {"fail_silently": True})
+
+    def test_queueing_failure_always_raises(self) -> None:
+        message = mail.EmailMessage(**self.message_data)
+        backend = Q2EmailBackend(fail_silently=True)
+
+        with (
+            patch(TARGET_ASYNC_TASK, side_effect=OSError("broker is down")),
+            self.assertRaises(OSError),
+        ):
+            backend.send_messages([message])
 
     def test_send_email(self) -> None:
         message = mail.EmailMessage(**self.message_data)


### PR DESCRIPTION
Stacked on #98 — based on `django-61`, so it should retarget to `main` once
that merges. Only the last commit is new.

`fail_silently` was accepted and did nothing: it binds to the deprecated
positional argument and went no further, so the worker sent without it and
failed the task on exactly the error the caller asked to have silenced.

Forwarding the flag is the whole fix. Calling what the worker calls, against
SMTP on a dead port:

```
init_kwargs={}                        ConnectionRefusedError -> task FAILS
init_kwargs={'fail_silently': True}   returned normally      -> task SUCCEEDS
```

Django's own backend swallows the error and returns 0, `send_message` returns
normally, and django-q marks the task successful. That is what sending
synchronously with `fail_silently=True` does.

Queueing still raises regardless of the flag. A message that cannot be queued
is not sent later either, so swallowing it would drop the mail leaving no task
and no record — the opposite of what a caller passing `fail_silently` wants,
which is about the email not sending.

Under `MAILERS` there is nothing to forward, since the mailer named by `using`
carries its own options. The README says to set it there, and notes that a
silenced failure leaves a successful task and no email.

## Testing

Two tests: the flag reaches the worker, and a queueing failure raises even with
`fail_silently=True`. 14 tests passing on Django 5.2, 6.0 and 6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)