### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license = { "file" = "LICENSE" }
 name = "django-q2-email-backend"
 readme = "README.rst"
 requires-python = ">=3.10"
-version = "2.1.0"
+version = "3.0.0"
 
 [dependency-groups]
 test = ["coverage[toml]", "django-stubs", "ruff", "ty"]


### PR DESCRIPTION
Major, because #98 dropped Django 4.2 and 5.1, and `Q2EmailBackend` no longer
accepts `fail_silently` positionally — it was the only positional parameter, so
`Q2EmailBackend(True)` now raises `TypeError`. Django itself only ever
constructs backends with keywords, so nothing in normal use is affected.

Everything else is additive: `MAILERS` support alongside the deprecated
`EMAIL_BACKEND` and `Q2_EMAIL_BACKEND` settings, which keep working until
Django 7.0 removes them.

Tagging this releases to PyPI through the existing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)