### PR TITLE
Stop reporting coverage to Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,7 @@ jobs:
           uv pip install -e .
           uv pip install django~=${{ matrix.django-version }}.0
       - name: Run tests
-        run: python -m coverage run runtests.py
-      - name: Generate coverage report
-        run: python -m coverage xml
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        run: python runtests.py
 
   checks:
     if: always()


### PR DESCRIPTION
The upload broke more often than it said anything useful.

Also drops `coverage run` and `coverage xml` from CI, since nothing consumes
the data once the upload is gone — that was 11 jobs generating a report to
throw away. Tests now run as `python runtests.py`.

`coverage[toml]` stays in the test dependency group and `[tool.coverage.run]`
stays in `pyproject.toml`, so `coverage run runtests.py` still works locally.
Say the word if you'd rather those went too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)